### PR TITLE
Automatically fetch enabled mod list

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -3,11 +3,13 @@
 base_game_path = D:\SteamLibrary\steamapps\common\Stellaris
 # MOD文件夹路径（群星创意工坊下载目录） | MOD folder path (Stellaris Steam Workshop download directory)
 mod_folder_path = D:\SteamLibrary\steamapps\workshop\content\281990
+# Translate me! | dlc_load.json relative path (Stellaris Documents directory)
+dlc_load_path = \Documents\Paradox Interactive\Stellaris
 
 [mod_filter]
 # 是否启用MOD过滤功能 (true/false) | Enable MOD filtering feature (true/false)
 # 启用后可以选择性扫描特定的MOD | When enabled, allows selective scanning of specific MODs
-enable_mod_filter = false
+enable_mod_filter = true
 
 # 要忽略扫描的MOD ID列表，用逗号分隔（黑名单） | List of MOD IDs to ignore during scan, separated by commas (blacklist)
 # 例如: ignored_mods = 123456789,987654321,555666777 | Example: ignored_mods = 123456789,987654321,555666777

--- a/descriptor.mod
+++ b/descriptor.mod
@@ -1,4 +1,4 @@
-version="1.0.2"
+version="1.1.0"
 tags={
 	"Utilities"
 }


### PR DESCRIPTION
Also includes local mods in Documents/Paradox Interactive/Stellaris/mod in case you want to support reading from those. Filtering is now enabled by default.